### PR TITLE
feat: add support for non-app dir as Workspace root dir

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,6 +14,10 @@ Supported ways to run tests:
 # Setup
 
 - Configure `frappeTestRunner.siteName` in settings. This site will be used by bench to run tests on.
+- If your Workspace root directory is not the app directory, also configure `frappeTestRunner.workspaceRoot` accordingly:
+  - `bench`: If your Workspace root directory is the same as the bench root directory
+  - `apps`: If your Workspace root directory is the "apps" folder
+  - `single-app`: Default. If your Workspace root directory is the app directory
 
 ## Usage
 

--- a/package.json
+++ b/package.json
@@ -23,6 +23,12 @@
                     "default": "frappe.localhost",
                     "description": "Name of frappe site to run tests on"
                 },
+                "frappeTestRunner.workspaceRoot": {
+                    "type": ["string"],
+                    "default": "single-app",
+                    "enum": ["single-app", "apps", "bench"],
+                    "description": "Set your Workspace root. Default assumes Workspace root is test app directory"
+                },
                 "frappeTestRunner.testArgs": {
                     "type": "string",
                     "default": "",

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -57,7 +57,7 @@ function getBaseTestCommand(): string | undefined {
     return `bench --site ${siteName} run-tests --module ${testModule} ${testArgs}`;
 }
 
-function getTestModule(userWorkspaceRoot: string): string | undefined {
+function getTestModule(userWorkspaceRoot: string | undefined): string | undefined {
 
     const workspaceRoot = vscode.workspace.rootPath;
     if (!workspaceRoot) {


### PR DESCRIPTION
A potential solution for #2. Introduces a new setting, `workspaceRoot`, which can be one of [single-app, apps, bench], with "single-app" being the default and resulting in no change in the behavior. 

Selecting one of the other settings takes them into account when forming the path of the test.